### PR TITLE
Feature: find blueprint

### DIFF
--- a/api/blueprints/find.js
+++ b/api/blueprints/find.js
@@ -1,0 +1,34 @@
+/**
+ * Module dependencies
+ */
+var actionUtil = require('sails/lib/hooks/blueprints/actionUtil'),
+    localFind = require('sails/lib/hooks/blueprints/actions/find');
+
+/**
+ * Find Records from FM API
+ *
+ *  get   /:modelIdentity
+ *   *    /:modelIdentity/find
+ *
+ * An API call to find and return model instances from the FM API.
+ * If in development, the local sails models will be queried instead
+ *
+ */
+
+module.exports = function findRecords (req, res) {
+
+  if (sails.config.environment === 'production') {
+
+    // Query FM API
+    fmAPI.get(req.url).on('complete', function (response) {
+      res.ok(response);
+    });
+
+  } else {
+
+    // Use mocked API through sails original find blueprint
+    return localFind(req, res);
+
+  }
+
+};

--- a/api/controllers/Player/queueController.js
+++ b/api/controllers/Player/queueController.js
@@ -5,25 +5,9 @@
  * @help        :: See http://sailsjs.org/#!/documentation/concepts/Controllers
  */
 
-var rest = require('restler');
 
-var FM = rest.service(function(u, p) {
-  this.defaults.username = u;
-  this.defaults.password = p;
-}, {
-  baseURL: 'http://localdocker:5000'
-}, {
-  update: function(track) {
-    return this.put('/player/queue', track);
-  }
-});
 
 module.exports = {
-  find: function (req, res) {
-    var fm = new FM('', '');
-    fm.get(req.url).on('complete', function (response) {
-      res.send(response);
-    });
-  }
+
 };
 

--- a/api/services/fmAPI.js
+++ b/api/services/fmAPI.js
@@ -1,0 +1,25 @@
+'use strict';
+/**
+ * Module dependencies
+ */
+var rest = require('restler');
+
+/**
+ * FM API Service
+ *
+ * @description :: Service for communicating with FM API
+ */
+
+
+var FM = rest.service(function(u, p) {
+  this.defaults.username = u;
+  this.defaults.password = p;
+}, {
+  baseURL: 'http://localdocker:5000'
+}, {
+  update: function(track) {
+    return this.put('/player/queue', track);
+  }
+});
+
+module.exports = new fmAPI('', '');

--- a/config/models.js
+++ b/config/models.js
@@ -17,7 +17,7 @@ module.exports.models = {
   * connections (see `config/connections.js`)                                *
   *                                                                          *
   ***************************************************************************/
-  // connection: 'localDiskDb',
+  connection: 'localDiskDb',
 
   /***************************************************************************
   *                                                                          *

--- a/config/routes.js
+++ b/config/routes.js
@@ -35,7 +35,7 @@ module.exports.routes = {
   '/': {
     view: 'homepage'
   },
-  'GET /player/queue*': 'Player/queueController.find'
+  'GET /player/queue*': { blueprint: 'find', model: 'queue' }
 
   /***************************************************************************
   *                                                                          *


### PR DESCRIPTION
This demonstrates my idea for making our calling logic reusable. It moves it to a custom find blueprint which is then configured for that route. It also implements sails local DB models if not in production mode, we could use this for mocking data before the API is ready.

This could act as a default, if we need to add additional behaviour to a particular endpoint we could add this is the controller as normal.

The FM API wrapper is moved to a service to make it reusable across the system. 
### Steps to try out:
1. run `sails lift --prod` to forward requests to FM API running on localdocker
2. run `sails lift` data will be returned from local sails model using the simple development localDiskDb
