### PR TITLE
Feature: event integration

### DIFF
--- a/api/models/Player/queue.js
+++ b/api/models/Player/queue.js
@@ -16,6 +16,11 @@ module.exports = {
 
   attributes: {
 
+    uri: {
+      type: 'string',
+      primaryKey: true
+    }
+
   }
 };
 

--- a/api/services/EventService.js
+++ b/api/services/EventService.js
@@ -1,0 +1,97 @@
+'use strict';
+/**
+ * Module dependencies
+ * @external
+ */
+var redis = require('redis'),
+    url = require('url');
+
+/**
+ * Redis client
+ * @property {Object} client
+ */
+var client;
+
+/**
+ * Connection config to use for redis pub/sub
+ * @property {String} connectionName
+ */
+var connectionName = 'fmEvents';
+
+/**
+ * Redis pub/sub connection configuration
+ * @property {Object} connection
+ */
+var connection = sails.config.connections[connectionName];
+
+
+module.exports = {
+
+  /**
+   * Initialise redis connection and event handlers
+   * @method init
+   */
+  init: function init () {
+    if (connection.host) {
+      client = redis.createClient(
+        url.parse(connection.host).port,
+        url.parse(connection.host).hostname
+      );
+      client.on('ready', this.onReady);
+      client.on('error', function (err) {
+        sails.log.error(err);
+      });
+      client.on('message', this.handleMessage);
+    }
+  },
+
+  /**
+   * Subscribe to redis channel
+   * @method onReady
+   */
+  onReady: function onReady () {
+    client.subscribe(connection.channel);
+    sails.log.info('Connected to redis at ' + connection.host);
+    sails.log.info('Subscribed to ' + connection.channel);
+  },
+
+  /**
+   * Map redis events to resources
+   * @method handleMessage
+   */
+  handleMessage: function handleMessage (event, message) {
+
+    sails.log.debug(event, message);
+    message = JSON.parse(message);
+
+    switch(message.event) {
+      case 'add':
+        sails.models['player/queue'].publishCreate({ uri: message.uri });
+        break;
+      case 'play':
+        sails.models['player/queue'].publishDestroy({ uri: message.uri });
+        // publishUpdate on player/current
+        break;
+      case 'end':
+        // publishUpdate on player/current
+        break;
+      case 'pause':
+        // publishCreate on player/pause
+        break;
+      case 'resume':
+        // publishDestroy on player/pause
+        break;
+      case 'volume_changed':
+        // publishUpdate on player/volume
+        break;
+      case 'mute_changed':
+        // publishUpdate on player/mute
+        break;
+      default:
+        sails.log.debug('Unmatched redis event: ' + message.event);
+        break;
+    }
+
+  }
+
+};

--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -11,6 +11,8 @@
 
 module.exports.bootstrap = function(cb) {
 
+  EventService.init();
+
   // It's very important to trigger this callback method when you are finished
   // with the bootstrap!  (otherwise your server will never lift, since it's waiting on the bootstrap)
   cb();

--- a/config/connections.js
+++ b/config/connections.js
@@ -39,6 +39,15 @@ module.exports.connections = {
     pathname: ''
   },
 
+  /**
+   * Redis PubSub server for FM service events
+   * (no adpater required as its only used for events not storage)
+   */
+  fmEvents: {
+    host: process.env.REDIS_URI || 'redis://redis:6379',
+    channel: process.env.REDIS_CHANNEL || 'fm:events'
+  },
+
   /***************************************************************************
   *                                                                          *
   * MySQL is the world's most popular relational database.                   *

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "include-all": "~0.1.3",
     "lodash": "^3.10.1",
     "rc": "~0.5.0",
+    "redis": "^0.12.1",
     "sails": "~0.11.0",
     "sails-disk": "~0.10.0",
     "sails-rest": "git://github.com/zohararad/sails-rest.git#v0.1.0-waterline-v0.10"


### PR DESCRIPTION
This PR maps events from the redis PubSub system to the resourceful PubSub in sails, which will allow the FE to subscribe to the sails socket for events. For future applications this service could listen to events from any other transport, dependant on the backend service implementation.

> Note: this will need to be updated as we configure more endpoints
