### PR TITLE
Feature: resolve custom service routes

### DIFF
--- a/api/controllers/UsersController.js
+++ b/api/controllers/UsersController.js
@@ -1,0 +1,11 @@
+/**
+ * UsersController
+ *
+ * @description :: Server-side logic for managing Users
+ * @help        :: See http://sailsjs.org/#!/documentation/concepts/Controllers
+ */
+
+module.exports = {
+	
+};
+

--- a/api/controllers/UsersStatsController.js
+++ b/api/controllers/UsersStatsController.js
@@ -1,0 +1,11 @@
+/**
+ * UsersStatsController
+ *
+ * @description :: Server-side logic for managing Usersstats
+ * @help        :: See http://sailsjs.org/#!/documentation/concepts/Controllers
+ */
+
+module.exports = {
+	
+};
+

--- a/api/models/Users.js
+++ b/api/models/Users.js
@@ -1,0 +1,23 @@
+/**
+* Users.js
+*
+* @description :: TODO: You might write a short summary of how this model works and what it represents here.
+* @docs        :: http://sailsjs.org/#!documentation/models
+*/
+
+module.exports = {
+
+  autoPk: false,
+  autoCreatedAt: false,
+  autoUpdatedAt: false,
+
+  attributes: {
+
+    id: {
+      type: 'string',
+      primaryKey: true
+    }
+
+  }
+};
+

--- a/api/models/UsersStats.js
+++ b/api/models/UsersStats.js
@@ -1,0 +1,21 @@
+/**
+* UsersStats.js
+*
+* @description :: TODO: You might write a short summary of how this model works and what it represents here.
+* @docs        :: http://sailsjs.org/#!documentation/models
+*/
+
+module.exports = {
+
+  url: 'users/:user/stats',
+
+  attributes: {
+
+    user: {
+      type: 'string',
+      primaryKey: true
+    }
+
+  }
+};
+

--- a/config/connections.js
+++ b/config/connections.js
@@ -1,4 +1,10 @@
 /**
+ * Module dependencies
+ */
+var sailsRestConfig = require('./sailsRest'),
+    defaultHooks = require('sails-rest/lib/hooks');
+
+/**
  * Connections
  * (sails.config.connections)
  *
@@ -35,7 +41,12 @@ module.exports.connections = {
   fm: {
     adapter: 'sails-rest',
     host: process.env.FM_API_URI,
-    protocol: 'http'
+    protocol: 'http',
+    hooks: {
+      merge: false,
+      before: [defaultHooks.before[0], sailsRestConfig.createEndpoint],
+      after: [defaultHooks.after[0]]
+    }
   },
 
   /**

--- a/config/routes.js
+++ b/config/routes.js
@@ -53,7 +53,8 @@ module.exports.routes = {
   'GET /api/player/mute':       { model: 'player/mute',       blueprint: 'findasobject' },
   'GET /api/player/volume':     { model: 'player/volume',     blueprint: 'findasobject' },
   'GET /api/player/queue/meta': { model: 'player/queue/meta', blueprint: 'findasobject' },
-  'GET /api/player/stats':      { model: 'player/stats', blueprint: 'findasobject' }
+  'GET /api/player/stats':      { model: 'player/stats', blueprint: 'findasobject' },
 
+  'GET /api/users/:id/stats':   { model: 'usersstats', blueprint: 'find' }
 
 };

--- a/config/sailsRest.js
+++ b/config/sailsRest.js
@@ -1,0 +1,55 @@
+'use strict';
+/**
+ * Module dependencies
+ */
+var url = require('url'),
+    pathToRegexp = require('path-to-regexp');
+
+/**
+ * Custom hooks for sails-rest adapter
+ * @module sailsRest
+ */
+
+module.exports = {
+
+  /**
+   * Create an HTTP request URL from connection configuration, collection name and query options object.
+   * If query options object contains an `id` field, the HTTP URL will be formatted as proto://pathname/collection/id.
+   * Otherwise the HTTP URL will be formatted as proto://pathname/collection.
+   *
+   * @param {Request} req    - SuperAgent HTTP Request object
+   * @param {String}  method - HTTP request method
+   * @param {Object}  config - configuration object used to hold request-specific configuration. this is used to avoid polluting the connection's own configuration object.
+   * @param {Object}  conn   - connection configuration object:
+   *                         - {Object} connection - Waterline connection configuration object
+   *                         - {String} collection - collection name. appended to API pathname.
+   *                           For example, given the api `http://localhost:8080/api/v1`,
+   *                           a collection named `user` will resolve to `http://localhost:8080/api/v1/user`.
+   *                           A custom url pattern can be set in `url` key on model `users/:id/stats`, this will resolve to  `users/1/stats` using route options
+   *                         - {Object} options - query options object. contains query conditions (`where`), sort, limit etc. as per Waterline's API.
+   *                         - {Array<Object>} values - values of records to create.
+   */
+  createEndpoint: function createEndpoint(req, method, config, conn){
+    var modelUrl = '/' + sails.models[conn.collection].url;
+
+    if (modelUrl){
+      // resolve service URL from model.url and options
+      // eg. /users/:user/stats => /users/1/stats
+      var toPath = pathToRegexp.compile(modelUrl),
+          options = conn.options;
+
+      config.endpoint = url.resolve(conn.connection.endpoint, toPath(options));
+      // need to remove resolve options to avoid attaching again as query params
+
+    } else if(_.isObject(conn.options) && conn.options.hasOwnProperty('id')){
+      // resolve url from model identity and id eg. /users/1
+      config.endpoint = url.resolve(conn.connection.endpoint + '/', conn.collection + '/' + conn.options.id);
+      delete conn.options.id;
+
+    } else {
+      // resolve url from model identity eg. /users
+      config.endpoint = url.resolve(conn.connection.endpoint + '/', conn.collection);
+    }
+  }
+
+};

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-jshint": "^0.11.2",
     "lodash": "^3.10.1",
+    "path-to-regexp": "^1.2.1",
     "prerender-node": "^2.0.2",
     "redis": "^0.12.1",
     "sails": "~0.11.0",


### PR DESCRIPTION
To resolve more complex routes like this #27 we need a way to resolve custom service urls from the model config.

This adds custom url resolving logic to the sails-rest before hook. It allows us to set the service url like [this](https://github.com/thisissoon/FM-Frontend-API/compare/feature/resolving-custom-service-routes?expand=1#diff-8bc6b4b31363fd9e5b3540a186c0119cR10). Params are resolved from route and query options.
### Example:

```
var model = {
  url: 'users/:user/stats'
};
```

Ideally `UserStats` would be `Users/Stats` but I had issues setting it up like that for some reason so I've added a custom route for it.

Fixes #27 
