### PR TITLE
Feature: events endpoint

### DIFF
--- a/api/controllers/EventController.js
+++ b/api/controllers/EventController.js
@@ -42,7 +42,6 @@ module.exports = {
       default:
         sails.log.debug('Invalid event: ' + req.body._event);
         return res.badRequest({ _errors: { _event: 'Event \'' + req.body._event + '\' is invalid.' }});
-        break;
     }
 
     return res.status(202).json({ message: 'All is well. The event will be passed on to FE socket subscribers.' });

--- a/api/controllers/EventController.js
+++ b/api/controllers/EventController.js
@@ -1,0 +1,53 @@
+'use strict';
+/**
+ * EventController
+ *
+ * @description :: Server-side logic for managing Events
+ * @help        :: See http://sailsjs.org/#!/documentation/concepts/Controllers
+ */
+
+module.exports = {
+
+  /**
+   * Provides endpoint to handle incoming events
+   * @method post
+   * @param {Object} req  Express request
+   * @param {Object} res  Express resonse
+   */
+  post: function post (req, res) {
+
+    switch(req.body._event) {
+      case 'add':
+        sails.models['player/queue'].publishCreate({ uri: req.body.uri });
+        break;
+      case 'play':
+        sails.models['player/queue'].publishDestroy({ uri: req.body.uri });
+        sails.models['player/current'].publishUpdate();
+        break;
+      case 'end':
+        sails.models['player/current'].publishUpdate();
+        break;
+      case 'pause':
+        // publishCreate on player/pause
+        break;
+      case 'resume':
+        // publishDestroy on player/pause
+        break;
+      case 'volume_changed':
+        sails.models['player/volume'].publishUpdate();
+        break;
+      case 'mute_changed':
+        sails.models['player/mute'].publishUpdate();
+        break;
+      default:
+        sails.log.debug('Invalid event: ' + req.body._event);
+        return res.badRequest({ _errors: { _event: 'Event \'' + req.body._event + '\' is invalid.' }});
+        break;
+    }
+
+    return res.status(202).json({ message: 'All is well. The event will be passed on to FE socket subscribers.' });
+
+  }
+
+};
+

--- a/api/policies/hmac.js
+++ b/api/policies/hmac.js
@@ -1,0 +1,65 @@
+'use strict';
+/**
+ * Module dependencies
+ */
+var crypto = require('crypto'),
+    clients = sails.config.clients;
+
+/**
+ * HMAC Verification
+ *
+ * @module      :: Policy
+ * @description :: Policy to verify client HMAC signature
+ *
+ */
+module.exports = function(req, res, next) {
+
+  /**
+   * @property {Object} errResponse
+   */
+  var errResponse = { _errors: {} };
+
+  // Validate signature header has been provided
+  if (!req.headers.signature) {
+    errResponse._errors.signature = 'Invalid Signature';
+    return res.badRequest(errResponse);
+  }
+
+  /**
+   * Id of client parsed from signature header
+   * @property {String} clientId
+   */
+  var clientId = req.headers.signature.split(':', 1)[0];
+
+  /**
+   * signature parsed from signature header
+   * @property {String} signature
+   */
+  var clientSignature = req.headers.signature.split(':', 2)[1];
+
+  /**
+   * Trusted secret key of client
+   * @property {String} key
+   */
+  var key = clients[clientId];
+
+  if (!key) {
+    errResponse._errors.signature = 'Invalid Signature';
+    return res.badRequest(errResponse);
+  }
+
+  /**
+   * Create signature from encoding request body with secret key, for comparison
+   * @property {String} signature
+   */
+  var signature = crypto.createHmac('sha256', key).update(new Buffer(req.body)).digest('base64');
+
+  // Verify provided signature against computed
+  if (clientSignature !== signature) {
+    errResponse._errors.signature = 'Invalid Signature';
+    return res.badRequest(errResponse);
+  }
+
+  return next();
+
+};

--- a/api/policies/hmac.js
+++ b/api/policies/hmac.js
@@ -2,8 +2,7 @@
 /**
  * Module dependencies
  */
-var crypto = require('crypto'),
-    clients = sails.config.clients;
+var crypto = require('crypto');
 
 /**
  * HMAC Verification
@@ -13,6 +12,12 @@ var crypto = require('crypto'),
  *
  */
 module.exports = function(req, res, next) {
+
+  /**
+   * Collection of trusted clients from config
+   * @property {Object} clients
+   */
+  var clients = sails.config.clients;
 
   /**
    * @property {Object} errResponse
@@ -52,7 +57,7 @@ module.exports = function(req, res, next) {
    * Create signature from encoding request body with secret key, for comparison
    * @property {String} signature
    */
-  var signature = crypto.createHmac('sha256', key).update(new Buffer(req.body)).digest('base64');
+  var signature = crypto.createHmac('sha256', key).update(req.body.toString()).digest('base64');
 
   // Verify provided signature against computed
   if (clientSignature !== signature) {

--- a/config/clients.js
+++ b/config/clients.js
@@ -1,0 +1,12 @@
+/**
+ * Clients
+ * (sails.config.clients)
+ *
+ * A collection of known clients and their HMAC verification keys
+ */
+
+module.exports.clients = {
+
+  perceptor: '1234'
+
+};

--- a/config/env/testing.js
+++ b/config/env/testing.js
@@ -6,6 +6,9 @@ module.exports = {
 
   environment: 'testing',
 
+  // Use alternative port to avoid clash with running app
+  port: 1338,
+
   hooks: {
       grunt: false
   },

--- a/config/policies.js
+++ b/config/policies.js
@@ -28,24 +28,8 @@ module.exports.policies = {
 
   // '*': true,
 
-  /***************************************************************************
-  *                                                                          *
-  * Here's an example of mapping some policies to run before a controller    *
-  * and its actions                                                          *
-  *                                                                          *
-  ***************************************************************************/
-	// RabbitController: {
+  EventController: {
+    post: ['hmac']
+  }
 
-		// Apply the `false` policy as the default for all of RabbitController's actions
-		// (`false` prevents all access, which ensures that nothing bad happens to our rabbits)
-		// '*': false,
-
-		// For the action `nurture`, apply the 'isRabbitMother' policy
-		// (this overrides `false` above)
-		// nurture	: 'isRabbitMother',
-
-		// Apply the `isNiceToAnimals` AND `hasRabbitFood` policies
-		// before letting any users feed our rabbits
-		// feed : ['isNiceToAnimals', 'hasRabbitFood']
-	// }
 };

--- a/config/routes.js
+++ b/config/routes.js
@@ -53,7 +53,9 @@ module.exports.routes = {
   'GET /api/player/mute':       { model: 'player/mute',       blueprint: 'findasobject' },
   'GET /api/player/volume':     { model: 'player/volume',     blueprint: 'findasobject' },
   'GET /api/player/queue/meta': { model: 'player/queue/meta', blueprint: 'findasobject' },
-  'GET /api/player/stats':      { model: 'player/stats', blueprint: 'findasobject' }
+  'GET /api/player/stats':      { model: 'player/stats', blueprint: 'findasobject' },
+
+  'POST /api/events':           'EventController.post'
 
 
 };

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "sails-rest": "git://github.com/zohararad/sails-rest.git#v0.1.0-waterline-v0.10"
   },
   "devDependencies": {
+    "chai": "^3.2.0",
     "grunt-contrib-coffee": "~0.10.1",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-cssmin": "~0.9.0",

--- a/tasks/config/watch.js
+++ b/tasks/config/watch.js
@@ -33,7 +33,7 @@ module.exports = function(grunt) {
         nospawn: false,
         livereload: true
       },
-      files: ['api/**/*', 'config/**/*'],
+      files: ['api/**/*', 'config/**/*', 'tests/**/*'],
       tasks: ['test']
     }
 	});

--- a/tests/integration/events.js
+++ b/tests/integration/events.js
@@ -1,0 +1,110 @@
+/**
+ * Integration tests for /api/events
+ * @module events
+ */
+
+var crypto = require('crypto');
+
+describe('Events', function () {
+
+  describe('POST /api/events', function () {
+
+    var eventData, signature
+
+    beforeEach(function () {
+      sails.config.clients.test = 'a1b2c3d4';
+
+      eventData = {
+        _event: 'add'
+      }
+
+      signature = crypto.createHmac('sha256', 'a1b2c3d4').update(eventData.toString()).digest('base64');
+    });
+
+    it('should handle add event', function (done) {
+
+      var publishCreate = sinon.stub(sails.models['player/queue'], 'publishCreate');
+      eventData.uri = 1;
+
+      request
+        .post('/api/events')
+        .set('Signature', 'test:' + signature)
+        .send(eventData)
+        .expect('Content-Type', /json/)
+        .expect(202)
+        .expect(function(res){
+          expect(res.body.message).to.equal('All is well. The event will be passed on to FE socket subscribers.');
+          expect(publishCreate).to.have.been.calledWith({ uri: 1 });
+        })
+        .end(done);
+    });
+
+    it('should handle play event', function (done) {
+
+      eventData._event = 'play';
+      eventData.uri = 1;
+
+      var publishDestroy = sinon.stub(sails.models['player/queue'], 'publishDestroy');
+      var publishUpdate = sinon.stub(sails.models['player/current'], 'publishUpdate');
+
+      request
+        .post('/api/events')
+        .set('Signature', 'test:' + signature)
+        .send(eventData)
+        .expect('Content-Type', /json/)
+        .expect(202)
+        .expect(function(res){
+          expect(res.body.message).to.equal('All is well. The event will be passed on to FE socket subscribers.');
+          expect(publishDestroy).to.have.been.calledWith({ uri: 1 });
+          expect(publishUpdate).to.have.been.calledWith();
+        })
+        .end(done);
+    });
+
+    it('should return error for invalid event', function (done) {
+
+      eventData._event = 'somethingRandom';
+
+      request
+        .post('/api/events')
+        .set('Signature', 'test:' + signature)
+        .send(eventData)
+        .expect('Content-Type', /json/)
+        .expect(400)
+        .expect(function(res){
+          expect(res.body._errors._event).to.equal('Event \'somethingRandom\' is invalid.');
+        })
+        .end(done);
+    });
+
+    it('should return bad request for invalid signature', function (done) {
+
+      signature = crypto.createHmac('sha256', 'something-wrong').update(eventData.toString()).digest('base64');
+
+      request
+        .post('/api/events')
+        .set('Signature', 'test:' + signature)
+        .send(eventData)
+        .expect('Content-Type', /json/)
+        .expect(400)
+        .expect(function(res){
+          expect(res.body._errors.signature).to.equal('Invalid Signature');
+        })
+        .end(done);
+    });
+
+    it('should return bad request for no signature', function (done) {
+      request
+        .post('/api/events')
+        .send(eventData)
+        .expect('Content-Type', /json/)
+        .expect(400)
+        .expect(function(res){
+          expect(res.body._errors.signature).to.equal('Invalid Signature');
+        })
+        .end(done);
+    });
+
+  });
+
+});

--- a/tests/unit/policies/hmac.js
+++ b/tests/unit/policies/hmac.js
@@ -1,0 +1,57 @@
+/**
+ * Unit tests for HMAC Policy
+ * @module hmac
+ */
+
+describe('Policy: HMAC', function () {
+
+  var hmac = require('../../../api/policies/hmac'),
+      crypto = require('crypto'),
+      req, res, next;
+
+  beforeEach(function () {
+
+    sails.config.clients = {
+      test: 'a1b2c3d4'
+    };
+
+    req = {
+      headers: {},
+      body: {}
+    };
+
+    res = {
+      badRequest: sinon.spy()
+    };
+
+    next = sinon.spy();
+
+    req.headers.signature = 'test:' + crypto.createHmac('sha256', sails.config.clients.test).update(req.body.toString()).digest('base64');
+
+  });
+
+
+  it('should return bad request for no signature', function () {
+    delete req.headers.signature;
+    hmac(req, res, next);
+    expect(res.badRequest).to.have.been.calledWith({ _errors: { signature: 'Invalid Signature' } });
+  });
+
+  it('should return bad request for unrecognised client', function () {
+    req.headers.signature = 'unknown:1234';
+    hmac(req, res, next);
+    expect(res.badRequest).to.have.been.calledWith({ _errors: { signature: 'Invalid Signature' } });
+  });
+
+  it('should return bad request for invalid signature', function () {
+    req.headers.signature = 'test:invalidsig';
+    hmac(req, res, next);
+    expect(res.badRequest).to.have.been.calledWith({ _errors: { signature: 'Invalid Signature' } });
+  });
+
+  it('should call next middleware if verification passes', function () {
+    hmac(req, res, next);
+    expect(next).to.have.been.calledWith();
+  });
+
+});

--- a/tests/unit/test.js
+++ b/tests/unit/test.js
@@ -1,7 +1,0 @@
-describe('Example', function () {
-
-  it('should run the tests', function () {
-    expect(1).to.equal(1);
-  });
-
-});


### PR DESCRIPTION
This PR provides an initial endpoint to handle incoming events from [Perceptor](https://github.com/thisissoon/FM-Perceptor).
#### `POST /api/events`

Accepts JSON data formatted as per the [Async Spec](https://github.com/thisissoon/Async-Specification).

Includes HMAC verification, the client secret key would need to be set [here](https://github.com/thisissoon/FM-Frontend-API/pull/35/files#diff-e9913724de2eb62f1ca0579f77bea579R10).

This supersedes the `EventService` which currently receives events from Redis.
